### PR TITLE
Disable Next telemetry

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,15 @@
 
 [[plugins]]
   package = "netlify-plugin-cypress"
+
+[context.production.environment]
+  NEXT_TELEMETRY_DISABLED=1
+
+[context.dev.environment]
+  NEXT_TELEMETRY_DISABLED=1
+
+[context.deploy-preview.environment]
+  NEXT_TELEMETRY_DISABLED=1
+
+[context.branch-deploy.environment]
+  NEXT_TELEMETRY_DISABLED=1

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "prebuild": "next telemetry disable",
     "build": "next build",
     "export": "next export"
   },


### PR DESCRIPTION
Next.js has telemetry enabled by default. Most of the time `NEXT_TELEMETRY_DISABLED=1` as an environment variable works, but sometimes disabling it in the CLI is necessary. Adding this to the template so that it can have telemetry **disabled** by default.